### PR TITLE
New  no-row-count-header property on SimpleTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ Prevent user interaction with Bootstrap back drop.
   | `selection-mode` | Selection mode | `none` or `single` or `multiple` | `none` |
   | `selected-items` | Selected items | Array of objects | `[]` |
   | `fixed-row-height` | Enable/disable the fixed row height feature. When `false` text will wrap and rows will have different height | `true` or `false` | `true` |
+  | `no-row-count-header`| Enable/disable the row count header | `true` or `false` | `false` |
   | `no-result-text` | Text displayed when there is no items | Any string | `Aucun résultat` |
   | `warning-template-text` | Warning template text shown when not all items are displayed. Must contain the `{maxRows}` token | Any string with `{maxRows}` | `Seuls les {maxRows} premiers résultats sont affichés.` |
   | `result-text` | Text displayed after the # of items | Any string | `résultat(s).` |

--- a/src/elements/simple-table/simple-table.html
+++ b/src/elements/simple-table/simple-table.html
@@ -6,7 +6,7 @@
     <table id="grid-${uniqueId}" class="table table-hover">
       <thead>
         <!-- results count -->
-        <tr if.bind="items.length > 0" class="table-info">
+        <tr if.bind="items.length > 0 && !noRowCountHeader" class="table-info">
           <th colspan="100%">
             <div>
               <small>${totalCount} ${resultText}</small>

--- a/src/elements/simple-table/simple-table.js
+++ b/src/elements/simple-table/simple-table.js
@@ -54,6 +54,10 @@ export class SimpleTable {
   @bindable({ defaultBindingMode: bindingMode.toView })
   selectionMode = 'none';
 
+  /** Enable/Disable the row count header. @type {boolean} */
+  @bindable({ defaultBindingMode: bindingMode.toView })
+  noRowCountHeader = false;
+
   /** Enable/Disable the fixed row height feature. @type {boolean} */
   @bindable({ defaultBindingMode: bindingMode.toView })
   fixedRowHeight = true;


### PR DESCRIPTION
New attribute property on SimpleTable component to hide optionally the row count header.