### PR TITLE
Add Bootsrap tooltip in simple-table

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,9 +651,22 @@ Prevent user interaction with Bootstrap back drop.
   | `header` | Header of the column | Any string representing a property present on the item | |
   | `cell-key` | Property of the item used to display as cell content | Any string representing a property present on the item | |
   | `sortable` | Is the column sortable | `true` or `false` | `false` |
-  | `sort-order` | Sorting order of the column | `true` or `false` | |
+  | `sort-order` | Sorting order of the column | `asc` or `desc` | |
   | `sort-type` | Sorting type |`text` or `numeric` | `text` |
   | `width` | CSS width of the column | Any css width expression | `auto` |
+
+#### Tooltips
+
+- If cells are too small to render completly (i.e. ellipsis is shown), Bootstrap tooltips will be automatically created on these cells.
+- If you use data-bs-* attribute on a column template, Bootstrap tootips will also be automatically created.
+    ```html
+    <column header="Id" cell-key="id">
+      <span data-bs-toggle="tooltip" data-bs-title="${item && item.name ? item.name : ' '}">
+        ${item.id}
+      </span>
+    </column>
+    ```
+    > Be sure to **always return a non empty string** for the title to avoid Bootstrap error.
 
 ### `input-mask` custom attribute
 

--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -312,10 +312,18 @@
             selected-items.bind="selectedItems"
             selection-mode="multiple">
             <column header="Id" cell-key="id" sortable="true" sort-type="numeric" width="80px">
-              <small><span class="badge text-bg-secondary">${item.id}</span></small>
+              <small>
+                <span
+                  class="badge text-bg-secondary"
+                  data-bs-toggle="tooltip"
+                  data-bs-placement="right"
+                  data-bs-title="${item && item.name ? item.name : ' '}">
+                  ${item.id}
+                </span>
+              </small>
             </column>
             <column header="Name" cell-key="name" sortable="true"></column>
-            <column header="Email" cell-key="email" sortable="true"></column>
+            <column header="Email" cell-key="email" sortable="true" width="220px"></column>
             <column header="Color" cell-key="color" width="120px">
               <div class="d-flex justify-content-between flex-nowrap">
                 <div class="fw-semibold m-0">${item.color}</div>

--- a/doc/src-elements-simple-table_simple-table.md
+++ b/doc/src-elements-simple-table_simple-table.md
@@ -6,20 +6,6 @@
 
 [Source file](../src/elements/simple-table/simple-table.js)
 
-## Functions
-
-### `setTooltipsIfApplicable(event)`
-
-![modifier: private](images/badges/modifier-private.png)
-
-Sets the tooltip on fixed-height td if applicable.
-
-Parameters | Type | Description
---- | --- | ---
-__event__ | `MouseEvent` | *mouse enter event*
-
----
-
 # Class `SimpleTable`
 
 Implements the **&#x60;simple-table&#x60; custom element** that provides a simple grid with customizable columns.
@@ -137,6 +123,22 @@ Synchronizes selection from the &#x60;values&#x60; attribute.
 
 ---
 
+### `removeSelectionTooltips()`
+
+![modifier: public](images/badges/modifier-public.png)
+
+Removes bootstrap tooltips on cells.
+
+---
+
+### `addSelectionTooltips()`
+
+![modifier: public](images/badges/modifier-public.png)
+
+Adds bootstrap tooltips on cells.
+
+---
+
 ### `datasourceChanged()`
 
 ![modifier: public](images/badges/modifier-public.png)
@@ -175,3 +177,4 @@ __totalCount__ | `number` | *The total count of items including not displayed on
 __allItemsDisplayed__ | `undefined` | *Are all items displayed?*
 __notDisplayedWarningText__ | `undefined` | *Warning text regarding items not displayed.*
 ___container__ | `HTMLTemplateElement` | *Html container of the custom element. @type {HTMLTemplateElement}*
+___tooltips__ | `Tooltip[]` | *Cells tooltips @type {Tooltip[]}*

--- a/ts-d-generation.json
+++ b/ts-d-generation.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
-    "lib": ["es2022"],
+    "lib": [
+      "es2022"
+    ],
+    "downlevelIteration": true,
     "allowJs": true,
     "checkJs": true,
     "baseUrl": "./src",
@@ -11,5 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "declarationMap": false
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
- If cells are too small to render completly (ellipsis is shown), Bootstrap tooltips are created on these cells
- If you use data-bs-* attribute on a column template, Bootstrap tootips are also created
    ```html
    <column header="Id" cell-key="id">
      <span data-bs-toggle="tooltip" data-bs-title="${item && item.name ? item.name : ' '}">
         ${item.id}
      </span>
    </column>
    ```
    > Be sure to **always return a non empty string** for the title to avoid Bootstrap error.