### PR TITLE
Various fixes and simple-table disabled attribute

### DIFF
--- a/dev-app/app.js
+++ b/dev-app/app.js
@@ -2,11 +2,11 @@ import { computedFrom, inject, NewInstance } from 'aurelia-framework';
 import { faker } from '@faker-js/faker';
 import { Validator, ValidationControllerFactory } from 'aurelia-validation';
 
+import { ExempleDialog } from './dialogs/exemple-dialog';
 import { AutoCompleteController } from 'resources/elements/auto-complete/auto-complete-controller';
 import { LockService } from 'core/lock-service/lock-service';
 import { ToastService } from 'core/toast-service/toast-service';
 import { DialogService } from 'core/dialog-service/dialog-service';
-import { ExempleDialog } from './dialogs/exemple-dialog';
 import { Adresse } from 'resources/elements/auto-complete/adresse';
 
 export const wait = delay => new Promise(resolve => setTimeout(resolve, delay));
@@ -130,7 +130,7 @@ export class App {
   }
 
   showItemDetails(data) {
-    console.log(data);
+    this.toast.info(data.name);
   }
 
   @computedFrom('selectedDialogMode')

--- a/src/elements/simple-table/simple-table.css
+++ b/src/elements/simple-table/simple-table.css
@@ -43,3 +43,8 @@ simple-table table td.fixed-height:has(> button) {
   overflow: visible;
   white-space: normal;
 }
+
+simple-table table.table-disabled {
+  pointer-events: none;
+  opacity: 0.6;
+}

--- a/src/elements/simple-table/simple-table.html
+++ b/src/elements/simple-table/simple-table.html
@@ -3,7 +3,7 @@
   <!-- where columns definition will be projected -->
   <slot></slot>
   <div class="table-wrapper" css="max-height: ${maxHeight}">
-    <table id="grid-${uniqueId}" class="table table-hover">
+    <table id="grid-${uniqueId}" class="table table-hover ${disabled ? 'table-disabled' : ''}">
       <thead>
         <!-- results count -->
         <tr if.bind="items.length > 0 && !noRowCountHeader" class="table-info">
@@ -44,7 +44,7 @@
         <!-- rows -->
         <tr
           repeat.for="item of items"
-          click.trigger="toggleItemSelection(item)"
+          click.trigger="toggleItemSelection(item, $event)"
           class="align-middle ${item.selected ? 'table-secondary' : ''} ${selectionMode != 'none' ? 'selection' : ''}">
           <!-- optional tick cell -->
           <td if.bind="selectionMode != 'none'" class="py-0 align-middle selection">

--- a/src/elements/simple-table/simple-table.js
+++ b/src/elements/simple-table/simple-table.js
@@ -28,6 +28,10 @@ export class SimpleTable {
   @bindable({ defaultBindingMode: bindingMode.toView })
   datasource;
 
+  /** Enable/Disable the custom element to prevent user modification. @type {boolean} */
+  @bindable({ defaultBindingMode: bindingMode.toView })
+  disabled = false;
+
   /** Maximal number of displayed rows. @type {number} */
   @bindable({ defaultBindingMode: bindingMode.toView })
   maxRows = 50;
@@ -136,11 +140,18 @@ export class SimpleTable {
   /**
    * Defines the logic triggered when item is clicked.
    * @param {T & {selected: boolean}} item item clicked or selected
-   * @param {boolean} notify should we dispatch custom element events?
+   * @param {Event} event click event
    * @returns {boolean} let event propagates
    */
-  toggleItemSelection(item, notify = true) {
+  toggleItemSelection(item, event) {
+    // no selection
     if (!this.valueKey || this.selectionMode === 'none') return true;
+    // click on button, a, ...
+    const target = /** @type {HTMLElement} */ (event.target);
+    if (target?.closest('a, button, input, select, textarea')) {
+      return true;
+    }
+    // do selection logic
     const actualSelection = this.selectedItems;
     const index = actualSelection.indexOf(item);
     if (index === -1) {
@@ -152,10 +163,9 @@ export class SimpleTable {
       this.selectedItems = [...this.selectedItems];
     }
     this.synchronizeSelection();
-    if (notify) {
-      this.triggerChangeEvent(this.selectedItems);
-      this.triggerBlurEvent(this.selectedItems);
-    }
+    this.triggerChangeEvent(this.selectedItems);
+    this.triggerBlurEvent(this.selectedItems);
+
     return true;
   }
 
@@ -213,7 +223,16 @@ export class SimpleTable {
    */
   removeSelectionTooltips() {
     this._taskqueue.queueTask(() => {
-      if (this._tooltips) [...this._tooltips].map(tooltip => tooltip?.dispose());
+      if (this._tooltips) {
+        for (const tooltip of this._tooltips) {
+          try {
+            tooltip.dispose();
+          } catch {
+            /* empty */
+          }
+        }
+        this._tooltips = undefined;
+      }
     });
   }
 


### PR DESCRIPTION
- **simple-table**: a click on a button or a link within a row should not trigger the row selection
- **simple-table**: sometimes an exception is thrown when tooltip are disposed
- **simple-table**: add a disabled attribute